### PR TITLE
fix local browsing in Fx, change to jsDelivr CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>jQuery Guillotine plugin</title>
   <link href='css/jquery.guillotine.css' media='all' rel='stylesheet'>
   <link href='css/demo.min.css' media='all' rel='stylesheet'>
-  <link href='//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css' rel='stylesheet'>
+  <link href='http://cdn.jsdelivr.net/fontawesome/4.2/css/font-awesome.min.css' rel='stylesheet'>
   <meta name='viewport' content='width=device-width, initial-scale=1.0, target-densitydpi=device-dpi'>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--[if lt IE 9]>
@@ -15,7 +15,7 @@
 <body>
   <div id='content'>
     <h1>
-      <a id='github' href='//github.com/matiasgagliano/guillotine' target='_blank'>
+      <a id='github' href='http://github.com/matiasgagliano/guillotine' target='_blank'>
         jQuery Guillotine
       </a>
     </h1>
@@ -26,7 +26,7 @@
     </div>
 
     <div class='frame'>
-      <img id='sample_picture' src='//lorempixel.com/640/480/city'>
+      <img id='sample_picture' src='http://lorempixel.com/640/480/city'>
     </div>
 
     <div id='controls'>
@@ -54,10 +54,10 @@
   </div>
 
   <a id='fork-me' href='//github.com/matiasgagliano/guillotine' target='_blank'>
-    <img alt='Fork me on GitHub' src="//s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
+    <img alt='Fork me on GitHub' src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
   </a>
 
-  <script src='//code.jquery.com/jquery-1.11.0.min.js'></script>
+  <script src='http://cdn.jsdelivr.net/jquery/1.11/jquery.min.js'></script>
   <script src='js/jquery.guillotine.min.js'></script>
   <script src='js/demo.min.js'></script>
 </body>


### PR DESCRIPTION
missing `http:` breaks local files browsing in Fx
Changed CDNs to jsDelivr; same [network + CloudFlare], 1 less DNS lookup, added auto minor revision [upgrades alias](https://github.com/jsdelivr/jsdelivr#version-aliasing)
