### PR TITLE
Fix plugin not initializing when image cached

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
   <script type='text/javascript'>
     jQuery(function() {
       var picture = $('#sample_picture');
-      picture.on('load', function(){
+      picture.one('load', function(){
         // Initialize plugin (with custom event)
         picture.guillotine({eventOnChange: 'guillotinechange'});
 
@@ -68,6 +68,8 @@
           data.scale = parseFloat(data.scale.toFixed(4));
           for(var k in data) { $('#'+k).html(data[k]); }
         });
+      }).each(function() {
+        if(this.complete) $(this).load();
       });
     });
   </script>


### PR DESCRIPTION
The load event isn't triggered in some browsers if the image is cached.
This leads to the plugin not initializing. Fixed in demo code. Am not
familiar enough with js/jQuery to explore option of fix within
Guillotine code itself.

Issue can be reliably replicated in Firefox 36 by loading page then
opening page again in same or new tab. Refreshing does not cause issue.
Issue is not caused in github.io example, possibly because new image
source is specific on each page load by script.